### PR TITLE
Main Coroutine Cleanup

### DIFF
--- a/app/src/test/java/com/github/odaridavid/weatherapp/MainCoroutineRule.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/MainCoroutineRule.kt
@@ -2,26 +2,20 @@ package com.github.odaridavid.weatherapp
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.*
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class MainCoroutineRule(
-    private val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
-) : TestWatcher(), TestCoroutineScope by TestCoroutineScope(dispatcher) {
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+
     override fun starting(description: Description) {
-        super.starting(description)
-        Dispatchers.setMain(dispatcher)
+        Dispatchers.setMain(testDispatcher)
     }
 
     override fun finished(description: Description) {
-        super.finished(description)
         Dispatchers.resetMain()
-        dispatcher.cancel()
     }
 }

--- a/app/src/test/java/com/github/odaridavid/weatherapp/MainCoroutineRule.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/MainCoroutineRule.kt
@@ -2,7 +2,10 @@ package com.github.odaridavid.weatherapp
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.*
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.resetMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 


### PR DESCRIPTION
## Related Issue
No Related Issue
## Description
Cleans up the deprecated TestCoroutineDispatcher and replaced with UnconfinedTestDispatcher
## How Can It Be Tested
All tests that require MainCoroutineRule runs smoothly 
## Screenshots (If Applicable)
N/A
## Additional Comments
N/A
## Checklist

- [ ] New tests were added/Existing Modified
