### PR TITLE
Refactor ApiResult.kt to Result and use of ErrorType 

### DIFF
--- a/app/src/main/java/com/github/odaridavid/weatherapp/core/Result.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/core/Result.kt
@@ -1,0 +1,15 @@
+package com.github.odaridavid.weatherapp.core
+
+sealed class Result<T> {
+    data class Success<T>(val data: T) : Result<T>()
+
+    data class Error<T>(val errorType: ErrorType) : Result<T>()
+}
+
+enum class ErrorType {
+    CLIENT,
+    SERVER,
+    GENERIC,
+    IO_CONNECTION,
+    UNAUTHORIZED
+}

--- a/app/src/main/java/com/github/odaridavid/weatherapp/core/api/WeatherRepository.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/core/api/WeatherRepository.kt
@@ -2,7 +2,7 @@ package com.github.odaridavid.weatherapp.core.api
 
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.core.model.Weather
-import com.github.odaridavid.weatherapp.data.weather.ApiResult
+import com.github.odaridavid.weatherapp.core.Result
 import kotlinx.coroutines.flow.Flow
 
 interface WeatherRepository {
@@ -10,5 +10,5 @@ interface WeatherRepository {
         defaultLocation: DefaultLocation,
         language: String,
         units: String
-    ) : Flow<ApiResult<Weather>>
+    ) : Flow<Result<Weather>>
 }

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/ApiResult.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/ApiResult.kt
@@ -1,9 +1,0 @@
-package com.github.odaridavid.weatherapp.data.weather
-
-import androidx.annotation.StringRes
-
-sealed class ApiResult<T> {
-    data class Success<T>(val data: T) : ApiResult<T>()
-
-    data class Error<T>(@StringRes val messageId: Int) : ApiResult<T>()
-}

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
@@ -1,31 +1,29 @@
 package com.github.odaridavid.weatherapp.data.weather
 
 import com.github.odaridavid.weatherapp.BuildConfig
-import com.github.odaridavid.weatherapp.R
+import com.github.odaridavid.weatherapp.core.ErrorType
+import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.core.model.ExcludedData
 import com.github.odaridavid.weatherapp.core.model.SupportedLanguage
 import com.github.odaridavid.weatherapp.core.model.Weather
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
-import java.io.IOException
-import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
 import javax.inject.Inject
 
 class DefaultWeatherRepository @Inject constructor(
     private val openWeatherService: OpenWeatherService,
     private val logger: Logger
 ) : WeatherRepository {
+
     override fun fetchWeatherData(
         defaultLocation: DefaultLocation,
         language: String,
         units: String
-    ): Flow<ApiResult<Weather>> = flow {
+    ): Flow<Result<Weather>> = flow {
 
         val excludedData = "${ExcludedData.MINUTELY.value},${ExcludedData.ALERTS.value}"
 
@@ -40,25 +38,15 @@ class DefaultWeatherRepository @Inject constructor(
 
         if (response.isSuccessful && response.body() != null) {
             val weatherData = response.body()!!.toCoreModel(unit = units)
-            emit(ApiResult.Success(data = weatherData))
+            emit(Result.Success(data = weatherData))
         } else {
-            val errorMessage = mapResponseCodeToErrorMessage(response.code())
-            emit(ApiResult.Error(errorMessage))
+            val errorType = mapResponseCodeToErrorType(response.code())
+            emit(Result.Error(errorType = errorType))
         }
-    }.catch { throwable ->
-        val errorMessage = when (throwable) {
-            is IOException -> R.string.error_connection
-            else -> R.string.error_generic
-        }
+    }.catch { throwable: Throwable ->
+        val errorType = mapThrowableToErrorType(throwable)
         logger.logException(throwable)
-        emit(ApiResult.Error(errorMessage))
-    }
-
-    private fun mapResponseCodeToErrorMessage(code: Int): Int = when (code) {
-        HTTP_UNAUTHORIZED -> R.string.error_unauthorized
-        in 400..499 -> R.string.error_client
-        in 500..600 -> R.string.error_server
-        else -> R.string.error_generic
+        emit(Result.Error(errorType))
     }
 
     private fun getLanguageValue(language: String) =

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/Mappers.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/Mappers.kt
@@ -1,6 +1,7 @@
 package com.github.odaridavid.weatherapp.data.weather
 
 import com.github.odaridavid.weatherapp.BuildConfig
+import com.github.odaridavid.weatherapp.core.ErrorType
 import com.github.odaridavid.weatherapp.core.model.CurrentWeather
 import com.github.odaridavid.weatherapp.core.model.DailyWeather
 import com.github.odaridavid.weatherapp.core.model.HourlyWeather
@@ -8,6 +9,8 @@ import com.github.odaridavid.weatherapp.core.model.Temperature
 import com.github.odaridavid.weatherapp.core.model.Units
 import com.github.odaridavid.weatherapp.core.model.Weather
 import com.github.odaridavid.weatherapp.core.model.WeatherInfo
+import java.io.IOException
+import java.net.HttpURLConnection
 import java.text.SimpleDateFormat
 import java.util.Date
 import kotlin.math.roundToInt
@@ -67,4 +70,19 @@ private fun getDate(utcInMillis: Long, formatPattern: String): String {
     val sdf = SimpleDateFormat(formatPattern)
     val dateFormat = Date(utcInMillis * 1000)
     return sdf.format(dateFormat)
+}
+
+fun mapThrowableToErrorType(throwable: Throwable): ErrorType {
+    val errorType = when (throwable) {
+        is IOException -> ErrorType.IO_CONNECTION
+        else -> ErrorType.GENERIC
+    }
+    return errorType
+}
+
+fun mapResponseCodeToErrorType(code: Int): ErrorType = when (code) {
+    HttpURLConnection.HTTP_UNAUTHORIZED -> ErrorType.UNAUTHORIZED
+    in 400..499 -> ErrorType.CLIENT
+    in 500..600 -> ErrorType.SERVER
+    else -> ErrorType.GENERIC
 }

--- a/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/HomeViewModel.kt
@@ -3,11 +3,13 @@ package com.github.odaridavid.weatherapp.ui.home
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.odaridavid.weatherapp.R
+import com.github.odaridavid.weatherapp.core.ErrorType
 import com.github.odaridavid.weatherapp.core.model.Weather
 import com.github.odaridavid.weatherapp.core.api.SettingsRepository
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
-import com.github.odaridavid.weatherapp.data.weather.ApiResult
+import com.github.odaridavid.weatherapp.core.Result
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -55,15 +57,16 @@ class HomeViewModel @Inject constructor(
                     }
                 }
             }
+
             is HomeScreenIntent.DisplayCityName -> {
                 setState { copy(locationName = homeScreenIntent.cityName) }
             }
         }
     }
 
-    private fun processResult(result: ApiResult<Weather>) {
+    private fun processResult(result: Result<Weather>) {
         when (result) {
-            is ApiResult.Success -> {
+            is Result.Success -> {
                 val weatherData = result.data
                 setState {
                     copy(
@@ -74,11 +77,11 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
-            is ApiResult.Error -> {
+            is Result.Error -> {
                 setState {
                     copy(
                         isLoading = false,
-                        errorMessageId = result.messageId
+                        errorMessageId = mapErrorTypeToResourceId(result.errorType)
                     )
                 }
             }
@@ -90,7 +93,6 @@ class HomeViewModel @Inject constructor(
             _state.emit(stateReducer(state.value))
         }
     }
-
 }
 
 data class HomeScreenViewState(

--- a/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/Mappers.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/Mappers.kt
@@ -1,0 +1,12 @@
+package com.github.odaridavid.weatherapp.ui.home
+
+import com.github.odaridavid.weatherapp.R
+import com.github.odaridavid.weatherapp.core.ErrorType
+
+fun mapErrorTypeToResourceId(errorType: ErrorType): Int = when (errorType) {
+    ErrorType.SERVER -> R.string.error_server
+    ErrorType.GENERIC -> R.string.error_generic
+    ErrorType.IO_CONNECTION -> R.string.error_connection
+    ErrorType.UNAUTHORIZED -> R.string.error_unauthorized
+    ErrorType.CLIENT -> R.string.error_client
+}

--- a/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
@@ -1,10 +1,11 @@
 package com.github.odaridavid.weatherapp
 
 import app.cash.turbine.test
+import com.github.odaridavid.weatherapp.core.ErrorType
 import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
-import com.github.odaridavid.weatherapp.data.weather.ApiResult
+import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
 import com.github.odaridavid.weatherapp.data.weather.OpenWeatherService
 import com.github.odaridavid.weatherapp.data.weather.WeatherResponse
@@ -54,8 +55,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Success::class.java)
-                Truth.assertThat((result as ApiResult.Success).data).isEqualTo(expectedResult)
+                Truth.assertThat(result).isInstanceOf(Result.Success::class.java)
+                Truth.assertThat((result as Result.Success).data).isEqualTo(expectedResult)
             }
             awaitComplete()
         }
@@ -88,8 +89,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_server)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.SERVER)
             }
             awaitComplete()
         }
@@ -122,8 +123,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_client)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.CLIENT)
             }
             awaitComplete()
         }
@@ -156,8 +157,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_unauthorized)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.UNAUTHORIZED)
             }
             awaitComplete()
         }
@@ -190,8 +191,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_generic)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.GENERIC)
             }
             awaitComplete()
         }
@@ -221,8 +222,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_connection)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.IO_CONNECTION)
             }
             awaitComplete()
         }
@@ -252,8 +253,8 @@ class WeatherRepositoryUnitTest {
             units = "metric"
         ).test {
             awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(ApiResult.Error::class.java)
-                Truth.assertThat((result as ApiResult.Error).messageId).isEqualTo(R.string.error_generic)
+                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
+                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.GENERIC)
             }
             awaitComplete()
         }


### PR DESCRIPTION
## Related Issue

N/A

## Description

Refactored `ApiResult` class to `Result` and moved it to `core`, also removed usage of `@StringRes` in the data layer for error messages. This was replaced by `ErrorType` to keep it platform agnostic, the mapping will occur in the UI layer.

## How Can It Be Tested

Errors are still shown as expected

## Screenshots (If Applicable)

## Checklist

- [x] New tests were added/Existing Modified
