### PR TITLE
Declutter Repository with new data source layer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ fun setupAndroidReporting() {
     val buildTypes = listOf("debug")
 
     buildTypes.forEach { buildTypeName ->
-        var sourceName = buildTypeName
+        val sourceName = buildTypeName
         val testTaskName = "test${sourceName.capitalize()}UnitTest"
         println("Task -> $testTaskName")
 

--- a/app/src/main/java/com/github/odaridavid/weatherapp/core/model/Throwables.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/core/model/Throwables.kt
@@ -1,0 +1,9 @@
+package com.github.odaridavid.weatherapp.core.model
+
+data class ClientException(override val message: String) : Throwable(message = message)
+
+data class ServerException(override val message: String) : Throwable(message = message)
+
+data class UnauthorizedException(override val message: String) : Throwable(message = message)
+
+data class GenericException(override val message: String) : Throwable(message = message)

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
@@ -1,55 +1,38 @@
 package com.github.odaridavid.weatherapp.data.weather
 
-import com.github.odaridavid.weatherapp.BuildConfig
-import com.github.odaridavid.weatherapp.core.ErrorType
 import com.github.odaridavid.weatherapp.core.Result
+import com.github.odaridavid.weatherapp.core.Result.Success
+import com.github.odaridavid.weatherapp.core.Result.Error
 import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
-import com.github.odaridavid.weatherapp.core.model.ExcludedData
-import com.github.odaridavid.weatherapp.core.model.SupportedLanguage
 import com.github.odaridavid.weatherapp.core.model.Weather
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
+import com.github.odaridavid.weatherapp.data.weather.remote.RemoteWeatherDataSource
+import com.github.odaridavid.weatherapp.data.weather.remote.mapThrowableToErrorType
 import javax.inject.Inject
 
 class DefaultWeatherRepository @Inject constructor(
-    private val openWeatherService: OpenWeatherService,
+    private val remoteWeatherDataSource: RemoteWeatherDataSource,
     private val logger: Logger
 ) : WeatherRepository {
 
-    override fun fetchWeatherData(
+    override suspend fun fetchWeatherData(
         defaultLocation: DefaultLocation,
         language: String,
         units: String
-    ): Flow<Result<Weather>> = flow {
-
-        val excludedData = "${ExcludedData.MINUTELY.value},${ExcludedData.ALERTS.value}"
-
-        val response = openWeatherService.getWeatherData(
-            longitude = defaultLocation.longitude,
-            latitude = defaultLocation.latitude,
-            excludedInfo = excludedData,
-            units = units,
-            language = getLanguageValue(language),
-            appid = BuildConfig.OPEN_WEATHER_API_KEY
-        )
-
-        if (response.isSuccessful && response.body() != null) {
-            val weatherData = response.body()!!.toCoreModel(unit = units)
-            emit(Result.Success(data = weatherData))
-        } else {
-            val errorType = mapResponseCodeToErrorType(response.code())
-            emit(Result.Error(errorType = errorType))
+    ): Result<Weather> =
+        try{
+            val weather = remoteWeatherDataSource.fetchWeatherData(
+                defaultLocation = defaultLocation,
+                units = units,
+                language = language
+            )
+            Success(weather) as Result<Weather>
+        } catch (throwable: Throwable) {
+            val errorType = mapThrowableToErrorType(throwable)
+            logger.logException(throwable)
+            Error(errorType)
         }
-    }.catch { throwable: Throwable ->
-        val errorType = mapThrowableToErrorType(throwable)
-        logger.logException(throwable)
-        emit(Result.Error(errorType))
-    }
 
-    private fun getLanguageValue(language: String) =
-        SupportedLanguage.values().first { it.languageName == language }.languageValue
 
 }

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/DefaultWeatherRepository.kt
@@ -21,13 +21,12 @@ class DefaultWeatherRepository @Inject constructor(
         language: String,
         units: String
     ): Result<Weather> =
-        try{
-            val weather = remoteWeatherDataSource.fetchWeatherData(
+        try {
+            remoteWeatherDataSource.fetchWeatherData(
                 defaultLocation = defaultLocation,
                 units = units,
                 language = language
             )
-            Success(weather) as Result<Weather>
         } catch (throwable: Throwable) {
             val errorType = mapThrowableToErrorType(throwable)
             logger.logException(throwable)

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/DefaultRemoteWeatherDataSource.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/DefaultRemoteWeatherDataSource.kt
@@ -1,0 +1,46 @@
+package com.github.odaridavid.weatherapp.data.weather.remote
+
+import com.github.odaridavid.weatherapp.BuildConfig
+import com.github.odaridavid.weatherapp.core.Result
+import com.github.odaridavid.weatherapp.core.model.DefaultLocation
+import com.github.odaridavid.weatherapp.core.model.ExcludedData
+import com.github.odaridavid.weatherapp.core.model.SupportedLanguage
+import com.github.odaridavid.weatherapp.core.model.Weather
+import javax.inject.Inject
+
+class DefaultRemoteWeatherDataSource @Inject constructor(
+    private val openWeatherService: OpenWeatherService
+) : RemoteWeatherDataSource {
+
+    override suspend fun fetchWeatherData(
+        defaultLocation: DefaultLocation,
+        language: String,
+        units: String
+    ): Result<Weather> =
+        try {
+
+            val excludedData = "${ExcludedData.MINUTELY.value},${ExcludedData.ALERTS.value}"
+
+            val response = openWeatherService.getWeatherData(
+                longitude = defaultLocation.longitude,
+                latitude = defaultLocation.latitude,
+                excludedInfo = excludedData,
+                units = units,
+                language = getLanguageValue(language),
+                appid = BuildConfig.OPEN_WEATHER_API_KEY
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val weatherData = response.body()!!.toCoreModel(unit = units)
+                Result.Success(data = weatherData)
+            } else {
+                val throwable = mapResponseCodeToThrowable(response.code())
+                throw throwable
+            }
+        } catch (e: Exception) {
+            throw e
+        }
+
+    private fun getLanguageValue(language: String) =
+        SupportedLanguage.values().first { it.languageName == language }.languageValue
+}

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/OpenWeatherService.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/OpenWeatherService.kt
@@ -1,4 +1,4 @@
-package com.github.odaridavid.weatherapp.data.weather
+package com.github.odaridavid.weatherapp.data.weather.remote
 
 import retrofit2.Response
 import retrofit2.http.GET

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/RemoteWeatherDataSource.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/RemoteWeatherDataSource.kt
@@ -1,15 +1,14 @@
-package com.github.odaridavid.weatherapp.core.api
+package com.github.odaridavid.weatherapp.data.weather.remote
 
+import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.core.model.Weather
-import com.github.odaridavid.weatherapp.core.Result
-import kotlinx.coroutines.flow.Flow
 
-interface WeatherRepository {
+interface RemoteWeatherDataSource {
 
     suspend fun fetchWeatherData(
         defaultLocation: DefaultLocation,
         language: String,
         units: String
-    ) : Result<Weather>
+    ): Result<Weather>
 }

--- a/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/WeatherResponse.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/data/weather/remote/WeatherResponse.kt
@@ -1,4 +1,4 @@
-package com.github.odaridavid.weatherapp.data.weather
+package com.github.odaridavid.weatherapp.data.weather.remote
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/com/github/odaridavid/weatherapp/di/ClientModule.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/di/ClientModule.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.github.odaridavid.weatherapp.BuildConfig
-import com.github.odaridavid.weatherapp.data.weather.OpenWeatherService
+import com.github.odaridavid.weatherapp.data.weather.remote.OpenWeatherService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/github/odaridavid/weatherapp/di/RepositoryModule.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/di/RepositoryModule.kt
@@ -6,6 +6,8 @@ import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.data.settings.DefaultSettingsRepository
 import com.github.odaridavid.weatherapp.data.weather.FirebaseLogger
+import com.github.odaridavid.weatherapp.data.weather.remote.DefaultRemoteWeatherDataSource
+import com.github.odaridavid.weatherapp.data.weather.remote.RemoteWeatherDataSource
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -23,5 +25,8 @@ interface RepositoryModule {
 
     @Binds
     fun bindFirebaseLogger(logger: FirebaseLogger): Logger
+
+    @Binds
+    fun bindRemoteWeatherDataSource(remoteWeatherDataSource: DefaultRemoteWeatherDataSource): RemoteWeatherDataSource
 
 }

--- a/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/HomeViewModel.kt
@@ -48,13 +48,12 @@ class HomeViewModel @Inject constructor(
         when (homeScreenIntent) {
             is HomeScreenIntent.LoadWeatherData -> {
                 viewModelScope.launch {
-                    weatherRepository.fetchWeatherData(
+                    val result = weatherRepository.fetchWeatherData(
                         language = state.value.language,
                         defaultLocation = state.value.defaultLocation,
                         units = state.value.units
-                    ).collect { result ->
-                        processResult(result)
-                    }
+                    )
+                    processResult(result)
                 }
             }
 

--- a/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/Mappers.kt
+++ b/app/src/main/java/com/github/odaridavid/weatherapp/ui/home/Mappers.kt
@@ -1,8 +1,10 @@
 package com.github.odaridavid.weatherapp.ui.home
 
+import androidx.annotation.StringRes
 import com.github.odaridavid.weatherapp.R
 import com.github.odaridavid.weatherapp.core.ErrorType
 
+@StringRes
 fun mapErrorTypeToResourceId(errorType: ErrorType): Int = when (errorType) {
     ErrorType.SERVER -> R.string.error_server
     ErrorType.GENERIC -> R.string.error_generic

--- a/app/src/test/java/com/github/odaridavid/weatherapp/Fakes.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/Fakes.kt
@@ -2,8 +2,8 @@ package com.github.odaridavid.weatherapp
 
 import com.github.odaridavid.weatherapp.core.model.CurrentWeather
 import com.github.odaridavid.weatherapp.core.model.Weather
-import com.github.odaridavid.weatherapp.data.weather.CurrentWeatherResponse
-import com.github.odaridavid.weatherapp.data.weather.WeatherResponse
+import com.github.odaridavid.weatherapp.data.weather.remote.CurrentWeatherResponse
+import com.github.odaridavid.weatherapp.data.weather.remote.WeatherResponse
 
 val fakeSuccessWeatherResponse = WeatherResponse(
     current = CurrentWeatherResponse(

--- a/app/src/test/java/com/github/odaridavid/weatherapp/HomeViewModelIntegrationTest.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/HomeViewModelIntegrationTest.kt
@@ -5,6 +5,7 @@ import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
+import com.github.odaridavid.weatherapp.data.weather.remote.DefaultRemoteWeatherDataSource
 import com.github.odaridavid.weatherapp.data.weather.remote.OpenWeatherService
 import com.github.odaridavid.weatherapp.data.weather.remote.WeatherResponse
 import com.github.odaridavid.weatherapp.ui.home.HomeScreenIntent
@@ -40,12 +41,7 @@ class HomeViewModelIntegrationTest {
     fun `when fetching weather data is successful, then display correct data`() = runBlocking {
         coEvery {
             mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
+                any(), any(), any(), any(), any(), any()
             )
         } returns Response.success<WeatherResponse>(
             fakeSuccessWeatherResponse
@@ -60,8 +56,7 @@ class HomeViewModelIntegrationTest {
         val expectedState = HomeScreenViewState(
             units = "metric",
             defaultLocation = DefaultLocation(
-                longitude = 0.0,
-                latitude = 0.0
+                longitude = 0.0, latitude = 0.0
             ),
             locationName = "-",
             language = "English",
@@ -82,16 +77,10 @@ class HomeViewModelIntegrationTest {
         runBlocking {
             coEvery {
                 mockOpenWeatherService.getWeatherData(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any()
+                    any(), any(), any(), any(), any(), any()
                 )
             } returns Response.error<WeatherResponse>(
-                404,
-                "{}".toResponseBody()
+                404, "{}".toResponseBody()
             )
 
             val weatherRepository = createWeatherRepository()
@@ -103,8 +92,7 @@ class HomeViewModelIntegrationTest {
             val expectedState = HomeScreenViewState(
                 units = "metric",
                 defaultLocation = DefaultLocation(
-                    longitude = 0.0,
-                    latitude = 0.0
+                    longitude = 0.0, latitude = 0.0
                 ),
                 locationName = "-",
                 language = "English",
@@ -122,16 +110,14 @@ class HomeViewModelIntegrationTest {
 
     @Test
     fun `when we init the screen, then update the state`() = runBlocking {
-        val weatherRepository =
-            createWeatherRepository()
+        val weatherRepository = createWeatherRepository()
 
         val viewModel = createViewModel(weatherRepository = weatherRepository)
 
         val expectedState = HomeScreenViewState(
             units = "metric",
             defaultLocation = DefaultLocation(
-                longitude = 0.0,
-                latitude = 0.0
+                longitude = 0.0, latitude = 0.0
             ),
             locationName = "-",
             language = "English",
@@ -156,8 +142,7 @@ class HomeViewModelIntegrationTest {
         val expectedState = HomeScreenViewState(
             units = "metric",
             defaultLocation = DefaultLocation(
-                longitude = 0.0,
-                latitude = 0.0
+                longitude = 0.0, latitude = 0.0
             ),
             locationName = "Paradise",
             language = "English",
@@ -177,11 +162,13 @@ class HomeViewModelIntegrationTest {
 
     private fun createViewModel(weatherRepository: WeatherRepository): HomeViewModel =
         HomeViewModel(
-            weatherRepository = weatherRepository,
-            settingsRepository = settingsRepository
+            weatherRepository = weatherRepository, settingsRepository = settingsRepository
         )
 
-
-    private fun createWeatherRepository() =
-        DefaultWeatherRepository(openWeatherService = mockOpenWeatherService, logger = mockLogger)
+    private fun createWeatherRepository() = DefaultWeatherRepository(
+        remoteWeatherDataSource = DefaultRemoteWeatherDataSource(
+            mockOpenWeatherService
+        ),
+        logger = mockLogger
+    )
 }

--- a/app/src/test/java/com/github/odaridavid/weatherapp/HomeViewModelIntegrationTest.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/HomeViewModelIntegrationTest.kt
@@ -5,8 +5,8 @@ import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
-import com.github.odaridavid.weatherapp.data.weather.OpenWeatherService
-import com.github.odaridavid.weatherapp.data.weather.WeatherResponse
+import com.github.odaridavid.weatherapp.data.weather.remote.OpenWeatherService
+import com.github.odaridavid.weatherapp.data.weather.remote.WeatherResponse
 import com.github.odaridavid.weatherapp.ui.home.HomeScreenIntent
 import com.github.odaridavid.weatherapp.ui.home.HomeScreenViewState
 import com.github.odaridavid.weatherapp.ui.home.HomeViewModel

--- a/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
@@ -7,8 +7,8 @@ import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
 import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
-import com.github.odaridavid.weatherapp.data.weather.OpenWeatherService
-import com.github.odaridavid.weatherapp.data.weather.WeatherResponse
+import com.github.odaridavid.weatherapp.data.weather.remote.OpenWeatherService
+import com.github.odaridavid.weatherapp.data.weather.remote.WeatherResponse
 import com.google.common.truth.Truth
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK

--- a/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
+++ b/app/src/test/java/com/github/odaridavid/weatherapp/WeatherRepositoryUnitTest.kt
@@ -1,13 +1,14 @@
 package com.github.odaridavid.weatherapp
 
-import app.cash.turbine.test
 import com.github.odaridavid.weatherapp.core.ErrorType
+import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.core.api.Logger
 import com.github.odaridavid.weatherapp.core.api.WeatherRepository
 import com.github.odaridavid.weatherapp.core.model.DefaultLocation
-import com.github.odaridavid.weatherapp.core.Result
 import com.github.odaridavid.weatherapp.data.weather.DefaultWeatherRepository
+import com.github.odaridavid.weatherapp.data.weather.remote.DefaultRemoteWeatherDataSource
 import com.github.odaridavid.weatherapp.data.weather.remote.OpenWeatherService
+import com.github.odaridavid.weatherapp.data.weather.remote.RemoteWeatherDataSource
 import com.github.odaridavid.weatherapp.data.weather.remote.WeatherResponse
 import com.google.common.truth.Truth
 import io.mockk.coEvery
@@ -28,240 +29,233 @@ class WeatherRepositoryUnitTest {
     val mockLogger = mockk<Logger>(relaxed = true)
 
     @Test
-    fun `when we fetch weather data successfully, then a successfully mapped result is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
+    fun `when we fetch weather data successfully, then a successfully mapped result is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns Response.success<WeatherResponse>(
+                fakeSuccessWeatherResponse
             )
-        } returns Response.success<WeatherResponse>(
-            fakeSuccessWeatherResponse
+
+            val weatherRepository = createWeatherRepository()
+
+            val expectedResult = fakeSuccessMappedWeatherResponse
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+            Truth.assertThat(actualResults).isInstanceOf(Result.Success::class.java)
+            Truth.assertThat((actualResults as Result.Success).data).isEqualTo(expectedResult)
+        }
+
+    @Test
+    fun `when we fetch weather data and a server error occurs, then a server error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns Response.error<WeatherResponse>(
+                500,
+                "{}".toResponseBody()
+            )
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType).isEqualTo(ErrorType.SERVER)
+        }
+
+    @Test
+    fun `when we fetch weather data and a client error occurs, then a client error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns Response.error<WeatherResponse>(
+                404,
+                "{}".toResponseBody()
+            )
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType).isEqualTo(ErrorType.CLIENT)
+        }
+
+    @Test
+    fun `when we fetch weather data and an unauthorized error occurs, then an unauthorized error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns Response.error<WeatherResponse>(
+                401,
+                "{}".toResponseBody()
+            )
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType)
+                .isEqualTo(ErrorType.UNAUTHORIZED)
+        }
+
+    @Test
+    fun `when we fetch weather data and a generic error occurs, then a generic error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } returns Response.error<WeatherResponse>(
+                800,
+                "{}".toResponseBody()
+            )
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType)
+                .isEqualTo(ErrorType.GENERIC)
+        }
+
+    @Test
+    fun `when we fetch weather data and an IOException is thrown, then a connection error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } throws IOException()
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType)
+                .isEqualTo(ErrorType.IO_CONNECTION)
+        }
+
+    @Test
+    fun `when we fetch weather data and an unknown Exception is thrown, then a generic error is emitted`() =
+        runBlocking {
+            coEvery {
+                mockOpenWeatherService.getWeatherData(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            } throws Exception()
+
+            val weatherRepository = createWeatherRepository()
+
+            val actualResults = weatherRepository.fetchWeatherData(
+                defaultLocation = DefaultLocation(
+                    longitude = 10.0,
+                    latitude = 12.90
+                ),
+                language = "English",
+                units = "metric"
+            )
+
+            Truth.assertThat(actualResults).isInstanceOf(Result.Error::class.java)
+            Truth.assertThat((actualResults as Result.Error).errorType)
+                .isEqualTo(ErrorType.GENERIC)
+        }
+
+    private fun createWeatherRepository(
+        logger: Logger = mockLogger,
+        remoteWeatherDataSource: RemoteWeatherDataSource = DefaultRemoteWeatherDataSource(
+            openWeatherService = mockOpenWeatherService
         )
-
-        val weatherRepository = createWeatherRepository()
-
-        val expectedResult = fakeSuccessMappedWeatherResponse
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Success::class.java)
-                Truth.assertThat((result as Result.Success).data).isEqualTo(expectedResult)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and a server error occurs, then a server error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns Response.error<WeatherResponse>(
-            500,
-            "{}".toResponseBody()
-        )
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.SERVER)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and a client error occurs, then a client error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns Response.error<WeatherResponse>(
-            404,
-            "{}".toResponseBody()
-        )
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.CLIENT)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and an unauthorized error occurs, then an unauthorized error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns Response.error<WeatherResponse>(
-            401,
-            "{}".toResponseBody()
-        )
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.UNAUTHORIZED)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and a generic error occurs, then a generic error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns Response.error<WeatherResponse>(
-            800,
-            "{}".toResponseBody()
-        )
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.GENERIC)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and an IOException is thrown, then a connection error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } throws IOException()
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.IO_CONNECTION)
-            }
-            awaitComplete()
-        }
-    }
-
-    @Test
-    fun `when we fetch weather data and an unknown Exception is thrown, then a generic error is emitted`() = runBlocking {
-        coEvery {
-            mockOpenWeatherService.getWeatherData(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } throws Exception()
-
-        val weatherRepository = createWeatherRepository()
-
-        weatherRepository.fetchWeatherData(
-            defaultLocation = DefaultLocation(
-                longitude = 10.0,
-                latitude = 12.90
-            ),
-            language = "English",
-            units = "metric"
-        ).test {
-            awaitItem().also { result ->
-                Truth.assertThat(result).isInstanceOf(Result.Error::class.java)
-                Truth.assertThat((result as Result.Error).errorType).isEqualTo(ErrorType.GENERIC)
-            }
-            awaitComplete()
-        }
-    }
-
-    private fun createWeatherRepository(logger: Logger = mockLogger): WeatherRepository = DefaultWeatherRepository(
-        openWeatherService = mockOpenWeatherService,
+    ): WeatherRepository = DefaultWeatherRepository(
+        remoteWeatherDataSource = remoteWeatherDataSource,
         logger = logger
     )
 }


### PR DESCRIPTION
## Related Issue

N/A

## Description

Adds a remote data source layer to the repo, making the repo a mediator between any data sources that will be added.

## How Can It Be Tested

The app still works as expected and tests continue to pass.

## Screenshots (If Applicable)

## Additional Comments

Replaced flows with coroutines, because it's a single-call operation, and that makes more sense.Meaning a slight change to error handling as well.

## Checklist

- [x] New tests were added/Existing Modified
