### PR TITLE
Add compose compiler reports plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -131,6 +131,7 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
         freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn" + listOf(
             "-P",
+            // See https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md
             "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir}/reports/kotlin-compile/compose"
         )
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,7 +129,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn" + listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.buildDir}/reports/kotlin-compile/compose"
+        )
     }
     buildFeatures {
         compose = true


### PR DESCRIPTION
## Related Issue

N/A

## Description

In an effort to be able to generate reports for compose compiler metrics and help evaluate performance with stable and unstable components and see where adjustments need to be made.

## How Can It Be Tested

Run 
```
./gradlew -Pandroidx.enableComposeCompilerReports=true :app:compileReleaseKotlin
```

Reports will be generated in the `build/reports/kotlin-compile` folder

## Screenshots (If Applicable)

## Additional Comments

## Checklist

- [ ] New tests were added/Existing Modified
